### PR TITLE
First version of new implementation of the deprecated rss module for sopel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,95 +1,59 @@
-###### ################
-##	project related
-### ###################
-
-###### ################
-##	system (linux)
-### ###################
-*~
-.svn/
-*.key
-
-###### ################
-##	java
-### ###################
-*.class
-
-###### ################
-##	nodejs / npm
-### ###################
-node_modules/
-lib-cov
-*.seed
-
-###### ################
-##	bowerjs
-### ###################
-bower_components/
-
-###### ################
-##	sailsjs
-### ###################
-.sails
-.waterline
-.rigging
-.tmp
-
-###### ################
-##	other
-### ###################
-*.log*
-.editorconfig
-
-###### ################
-##	system (osx)
-##	thx: http://goo.gl/y4dZq
-### ###################
-.DS_Store
-
-###### ################
-##	eclipse
-##	thx: http://goo.gl/y4dZq
-### ###################
-.classpath
-.project
-.settings/
-
-###### ################
-##	intellij
-##	thx: http://goo.gl/y4dZq
-### ###################
-.idea/
-*.iml
-*.iws
-
-###### ################
-##	maven
-##	thx: http://goo.gl/y4dZq
-### ###################
-target/
-
-###### ################
-##	android
-### ###################
-proguard_logs/
-
-###### ################
-##	gradle
-### ###################
-.gradle
-/local.properties
-/gradle.properties
-/.idea/workspace.xml
-/build
-
-###### ################
-##	python
-##	thx: http://goo.gl/WR3a3F
-### ###################
+# Byte-compiled / optimized / DLL files
 __pycache__/
-__init__.py
 *.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
 .cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Fabio Tea
+Copyright (c) 2015 Fabio Tea, RebelCodeBase
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# SOPEL RSS
-New implementation of the deprecated rss module for [sopel](https://github.com/sopel-irc/sopel)
+# sopel-rss
+
+New implementation of the deprecated rss module for [sopel](https://github.com/sopel-irc/sopel). This module motivated the [ansible-role-sopel-runit-debian](https://github.com/RebelCodeBase/ansible-role-sopel-runit-debian) which can be used to deploy the bot to a debian box.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,33 +5,33 @@ New implementation of the deprecated rss module for [sopel](https://github.com/s
 
 ### rssadd &mdash; add a feed
 
-**Syntax: .rssadd <channel> <name> <url> <interval>**
+**Syntax:** .rssadd \<channel\> \<name\> \<url\> \<interval\>
 
-*Requires: owner or admin*
+*Requires:* owner or admin
 
 ### rssdel &mdash; delete a feed
 
-**Syntax: .rssdel <id>|<name>**
+**Syntax:** .rssdel \<id\>|\<name\>
 
-*Requires: owner or admin*
+*Requires:* owner or admin
 
 ### rssdelallfeeds &mdash; delete all feeds
 
-**Syntax: rssdelallfeeds**
+**Syntax:** rssdelallfeeds
 
-*Requires: owner or admin, query with bot*
+*Requires:* owner or admin, query with bot
 
 ### rssget &mdash; read a feed and post new items
 
-**Syntax: .rssget <name> [<scope>]**
+**Syntax:** .rssget \<name\> [\<scope\>]
 
-*Requires: owner or admin*
+*Requires:* owner or admin
 
 ### rsslist &mdash; list feeds
 
-**Syntax: .rsslist**
+**Syntax:** .rsslist
 
-*Requires: owner or admin*
+*Requires:* owner or admin*
 
 ## Options
 
@@ -39,16 +39,16 @@ The following options can be set in the configuration file. Be aware that the bo
 
 ### feeds &mdash; feeds that should be posted to channels
 
-**Syntax: feeds=<channel1> <name1> <url1> <interval1>[,<channel2> <name2> <url2> <interval2>]...**
+**Syntax:** feeds=\<channel1\> \<name1\> \<url1\> \<interval1\>[,\<channel2\> \<name2\> \<url2\> \<interval2\>]...
 
-*Default: empty*
+*Default:* empty
 
 This is the main data of the bot which will be read when the bot is started or when the owner or an admin issues the command **.reload rss** in a query with the bot.
 
 ### del_by_id &mdash; allows to delete a feed by ID
 
-**Syntax: del_by_id=[True|False]*
+**Syntax:** del_by_id=[True|False]
 
-*Default: False*
+*Default:* False
 
 This option is dangerous because after a feed has been deleted the ID of all remaining feed (which can be determined by the command **.rsslist**) could change. Therefore, this option is disabled by default but can be enabled for faster deletion of feeds.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # SOPEL RSS
 New implementation of the deprecated rss module for [sopel](https://github.com/sopel-irc/sopel)
 
+## Installation
+
+Put *rss.py* in your *~/.sopel/modules* directory.
+
 ## Commands
 
 ### rssadd &mdash; add a feed
@@ -9,11 +13,15 @@ New implementation of the deprecated rss module for [sopel](https://github.com/s
 
 *Requires:* owner or admin
 
+Add the feed *\<url\>* to *\<channel\>* and *\<name\>* it. The feed will be read at approximately every *\<interval\>* seconds and new items will be automatically posted to *\<channel\>*.
+
 ### rssdel &mdash; delete a feed
 
 **Syntax:** *.rssdel \<id\>|\<name\>*
 
 *Requires:* owner or admin
+
+Use *.rsslist* to list get the names and IDs of all feeds. Deletion by ID is per default turned off (cf. Options: *del_by_id*).
 
 ### rssdelallfeeds &mdash; delete all feeds
 
@@ -21,11 +29,17 @@ New implementation of the deprecated rss module for [sopel](https://github.com/s
 
 *Requires:* owner or admin, query with bot
 
+This will delete all feeds. Be sure to keep a backup of you configuration file.
+
 ### rssget &mdash; read a feed and post new items
 
 **Syntax:** *.rssget \<name\> [\<scope\>]*
 
 *Requires:* owner or admin
+
+If not *scope* is given then the bot will post only new items. During the first run no item will be posted but the ID of the last feed item will be remembered (and written to disk in the config file, cf. Options: *feeds*).
+
+*scope* can only be all. In this case the bot will post the whole feed. Mainly useful for debugging.
 
 ### rsslist &mdash; list feeds
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # SOPEL RSS
-new implementation of the deprecated rss module for [sopel](https://github.com/sopel-irc/sopel)
+New implementation of the deprecated rss module for [sopel](https://github.com/sopel-irc/sopel)
+
+## Commands
+
+### rssadd &mdash; add a feed
+
+**Syntax: .rssadd <channel> <name> <url> <interval>**
+
+*Requires: owner or admin*
+
+### rssdel &mdash; delete a feed
+
+**Syntax: .rssdel <id>|<name>**
+
+*Requires: owner or admin*
+
+### rssdelallfeeds &mdash; delete all feeds
+
+**Syntax: rssdelallfeeds**
+
+*Requires: owner or admin, query with bot*
+
+### rssget &mdash; read a feed and post new items
+
+**Syntax: .rssget <name> [<scope>]**
+
+*Requires: owner or admin*
+
+### rsslist &mdash; list feeds
+
+**Syntax: .rsslist**
+
+*Requires: owner or admin*
+
+## Options
+
+The following options can be set in the configuration file. Be aware that the bot mustn't be running when editing the configuration file. Otherwise, your edits may be overwritten!
+
+### feeds &mdash; feeds that should be posted to channels
+
+**Syntax: feeds=<channel1> <name1> <url1> <interval1>[,<channel2> <name2> <url2> <interval2>]...**
+
+*Default: empty*
+
+This is the main data of the bot which will be read when the bot is started or when the owner or an admin issues the command **.reload rss** in a query with the bot.
+
+### del_by_id &mdash; allows to delete a feed by ID
+
+**Syntax: del_by_id=[True|False]*
+
+*Default: False*
+
+This option is dangerous because after a feed has been deleted the ID of all remaining feed (which can be determined by the command **.rsslist**) could change. Therefore, this option is disabled by default but can be enabled for faster deletion of feeds.

--- a/README.md
+++ b/README.md
@@ -5,33 +5,33 @@ New implementation of the deprecated rss module for [sopel](https://github.com/s
 
 ### rssadd &mdash; add a feed
 
-**Syntax:** .rssadd \<channel\> \<name\> \<url\> \<interval\>
+**Syntax:** *.rssadd \<channel\> \<name\> \<url\> \<interval\>*
 
 *Requires:* owner or admin
 
 ### rssdel &mdash; delete a feed
 
-**Syntax:** .rssdel \<id\>|\<name\>
+**Syntax:** *.rssdel \<id\>|\<name\>*
 
 *Requires:* owner or admin
 
 ### rssdelallfeeds &mdash; delete all feeds
 
-**Syntax:** rssdelallfeeds
+**Syntax:** *rssdelallfeeds*
 
 *Requires:* owner or admin, query with bot
 
 ### rssget &mdash; read a feed and post new items
 
-**Syntax:** .rssget \<name\> [\<scope\>]
+**Syntax:** *.rssget \<name\> [\<scope\>]*
 
 *Requires:* owner or admin
 
 ### rsslist &mdash; list feeds
 
-**Syntax:** .rsslist
+**Syntax:** *.rsslist*
 
-*Requires:* owner or admin*
+*Requires:* owner or admin
 
 ## Options
 
@@ -39,16 +39,16 @@ The following options can be set in the configuration file. Be aware that the bo
 
 ### feeds &mdash; feeds that should be posted to channels
 
-**Syntax:** feeds=\<channel1\> \<name1\> \<url1\> \<interval1\>[,\<channel2\> \<name2\> \<url2\> \<interval2\>]...
+**Syntax:** *feeds=\<channel1\> \<name1\> \<url1\> \<interval1\>[,\<channel2\> \<name2\> \<url2\> \<interval2\>]...*
 
 *Default:* empty
 
-This is the main data of the bot which will be read when the bot is started or when the owner or an admin issues the command **.reload rss** in a query with the bot.
+This is the main data of the bot which will be read when the bot is started or when the owner or an admin issues the command *.reload rss* in a query with the bot.
 
 ### del_by_id &mdash; allows to delete a feed by ID
 
-**Syntax:** del_by_id=[True|False]
+**Syntax:** *del_by_id=[True|False]*
 
 *Default:* False
 
-This option is dangerous because after a feed has been deleted the ID of all remaining feed (which can be determined by the command **.rsslist**) could change. Therefore, this option is disabled by default but can be enabled for faster deletion of feeds.
+This option is dangerous because after a feed has been deleted the ID of all remaining feed (which can be determined by the command *.rsslist*) could change. Therefore, this option is disabled by default but can be enabled for faster deletion of feeds.

--- a/README.md
+++ b/README.md
@@ -76,15 +76,6 @@ This option is dangerous because after a feed has been deleted the ID of all rem
 
 ### TODO
 
-#### Tests are missing
-
-#### Examples should be real examples not syntax explanations
-
-#### The cycle time of the bot (update feeds at most every *cycle* seconds) should be configurable. 
-
-This line decides if the update method for a feed will be called: 
- ```python
- if uptime % int(feed['interval']) < cycle
- ```
-
-#### The output format and fields should be configurable.
+* Tests are missing
+* Examples should be real examples not syntax explanations
+* The output format and fields should be configurable.

--- a/README.md
+++ b/README.md
@@ -76,11 +76,15 @@ This option is dangerous because after a feed has been deleted the ID of all rem
 
 ### TODO
 
-# The cycle time of the bot (update feeds at most every *cycle* seconds) should be configurable. 
+#### Tests are missing
+
+#### Examples should be real examples not syntax explanations
+
+#### The cycle time of the bot (update feeds at most every *cycle* seconds) should be configurable. 
 
 This line decides if the update method for a feed will be called: 
  ```python
  if uptime % int(feed['interval']) < cycle
  ```
 
-# The output format and fields should be configurable.
+#### The output format and fields should be configurable.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use *.rsslist* to list get the names and IDs of all feeds. Deletion by ID is per
 
 *Requires:* owner or admin, query with bot
 
-This will delete all feeds. Be sure to keep a backup of you configuration file.
+Delete all feeds without asking for confirmation. Be sure to keep a backup of you configuration file.
 
 ### rssget &mdash; read a feed and post new items
 
@@ -37,9 +37,9 @@ This will delete all feeds. Be sure to keep a backup of you configuration file.
 
 *Requires:* owner or admin
 
-If not *scope* is given then the bot will post only new items. During the first run no item will be posted but the ID of the last feed item will be remembered (and written to disk in the config file, cf. Options: *feeds*).
+If *scope* is omitted then the bot will post new items since the last run to the channel to which the feed has been added. During the first run no item will be posted but the ID of the last feed item will be remembered (and written to disk in the config file, cf. Options: *feeds*).
 
-*scope* can only be all. In this case the bot will post the whole feed. Mainly useful for debugging.
+*scope* can only be *all*. In this case the bot will post the whole feed to the channel to which the feed has been added. Mainly useful for debugging.
 
 ### rsslist &mdash; list feeds
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ This option is dangerous because after a feed has been deleted the ID of all rem
 
 ### TODO
 
-The cycle time of the bot (update feeds at most every *cycle* seconds) should be configurable. This line decides if the update method for a feed will be call: 
+The cycle time of the bot (update feeds at most every *cycle* seconds) should be configurable. 
+
+This line decides if the update method for a feed will be called: 
  ```python
  if uptime % int(feed['interval']) < cycle
  ```

--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ This option is dangerous because after a feed has been deleted the ID of all rem
 
 ### TODO
 
-The cycle time of the bot (update feeds at most every *cycle* seconds) should be configurable. 
+# The cycle time of the bot (update feeds at most every *cycle* seconds) should be configurable. 
 
 This line decides if the update method for a feed will be called: 
  ```python
  if uptime % int(feed['interval']) < cycle
  ```
- 
+
+# The output format and fields should be configurable.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ If *scope* is omitted then the bot will post new items since the last run to the
 
 *Requires:* owner or admin
 
+### rssjoin &mdash; join all feeds' channels
+
+**Syntax:** *.rssjoin*
+
+*Requires:* owner or admin
+
 ## Options
 
 The following options can be set in the configuration file. Be aware that the bot mustn't be running when editing the configuration file. Otherwise, your edits may be overwritten!

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Put *rss.py* in your *~/.sopel/modules* directory.
 
 *Requires:* owner or admin
 
-Add the feed *\<url\>* to *\<channel\>* and *\<name\>* it. The feed will be read at approximately every *\<interval\>* seconds and new items will be automatically posted to *\<channel\>*.
+Add the feed *\<url\>* to *\<channel\>* and *\<name\>* it. The feed will be read at approximately every *\<interval\>* seconds and new items will be automatically posted to *\<channel\>*. At most, the bot will update every 60 seconds.
 
 ### rssdel &mdash; delete a feed
 
@@ -66,3 +66,11 @@ This is the main data of the bot which will be read when the bot is started or w
 *Default:* False
 
 This option is dangerous because after a feed has been deleted the ID of all remaining feed (which can be determined by the command *.rsslist*) could change. Therefore, this option is disabled by default but can be enabled for faster deletion of feeds.
+
+### TODO
+
+The cycle time of the bot (update feeds at most every *cycle* seconds) should be configurable. This line decides if the update method for a feed will be call: 
+ ```python
+ if uptime % int(feed['interval']) < cycle
+ ```
+ 

--- a/rss.py
+++ b/rss.py
@@ -1,4 +1,5 @@
 import feedparser
+import operator
 from unidecode import unidecode
 from urllib.request import urlopen
 from sopel.tools import SopelMemory, SopelMemoryWithDefault
@@ -14,42 +15,113 @@ def setup(bot):
     bot.config.define_section('rss', RSSSection)
     bot.memory['rss'] = SopelMemory()
     bot.memory['rss']['feeds'] = []
-    config_read(bot)
+    _config_read(bot)
 
 
 def configure(config):
     config.define_section('rss', RSSSection)
-    config.rss.configure_setting('feeds', 'strings divided by a newline each consisting of name, url, interval and channel divided by spaces')
+    config.rss.configure_setting('feeds', 'strings divided by a newline each consisting of channel, name, url and interval divided by spaces')
 
-
-def config_read(bot):
-    if bot.config.rss.feeds[0]:
-        for feed in bot.config.rss.feeds:
-            atoms = feed.split(' ')
-            bot.memory['rss']['feeds'].append({'name':atoms[0],'url':atoms[1],'interval':atoms[2],'channel':atoms[3]})
-
-
-def config_save(bot):
-    # flatten feeds for config file
-    feeds = []
-    for feed in bot.memory['rss']['feeds']:
-        feeds.append(feed['name'] + ' ' + feed['url'] + ' ' + feed['interval'] + ' ' + feed['channel'])
-    bot.config.rss.feeds = [",".join(feeds)]
-
-    try:
-        bot.config.save()
-        # TODO: remove the next line
-        bot.say('saved config to disk!')
-    except:
-        bot.say('unable to save config to disk!')
 
 def shutdown(bot):
     print('shutting down...')
     bot.debug('rss', 'shutting down...', 'always')
-    config_save(bot)
+    _config_save(bot)
 
 
 @require_admin
+@commands('rssadd')
+@example('.rssadd <channel> <name> <url> <interval>')
+def rssadd(bot, trigger):
+    # check number of parameters
+    for i in range(2,7):
+        if trigger.group(i) is None:
+            bot.say('syntax: .{} <channel> <name> <url> <interval>'.format(trigger.group(1)))
+            return NOLIMIT
+    # TODO: check that no parameter contains a comma
+
+    # get arguments
+    channel = trigger.group(3)
+    name = trigger.group(4)
+    url = trigger.group(5)
+    interval = trigger.group(6)
+
+    # check that feed name is not a number
+    try:
+        int(name)
+    except ValueError:
+        pass
+    else:
+        bot.say('feed name "{}" is invalid, it has to contain at least one letter'.format(name))
+        return NOLIMIT
+
+    # check that feed name is unique
+    for feed in bot.memory['rss']['feeds']:
+        if name == feed['name']:
+            bot.say('feed name "{}" is already in use, please choose a different one'.format(name))
+            return NOLIMIT
+
+    # check that feed url is online
+    try:
+        with urlopen(url) as f:
+            if f.status == 200:
+                # save config to memory
+                bot.memory['rss']['feeds'].append({'channel':channel, 'name':name, 'url':url, 'interval':interval})
+                bot.say('rss feed "{}" added successfully'.format(url))
+    except:
+        bot.say('unable to add feed "{}": invalid url!'.format(url))
+        return NOLIMIT
+
+    _config_save(bot)
+
+    return NOLIMIT
+
+
+@require_admin
+@commands('rssdel')
+@example('.rssdel <index>|<name>')
+def rssdel(bot, trigger):
+    # get arguments
+    arg = trigger.group(3)
+
+    if arg is None:
+        bot.say('syntax: .{} <index>|<name>'.format(trigger.group(1)))
+        return NOLIMIT
+
+    # check if arg is a number
+    try:
+        int(arg)
+    except ValueError:
+        # arg is not a number
+        _delFeedByName(bot, arg)
+    else:
+        # arg is a number
+        _delFeedByIndex(bot, int(arg))
+
+    _config_save(bot)
+
+    return NOLIMIT
+
+
+# shoot yourself in the feet
+@require_privmsg
+@require_admin
+@commands('rssdeleteallfeeds')
+@example('.rssdeleteallfeeds')
+def rssdeleteallfeeds(bot, trigger):
+    # check number of parameters
+    if not trigger.group(2) is None:
+        bot.say('.{} must be called without parameters'.format(trigger.group(1)))
+        return NOLIMIT
+
+    bot.memory['rss']['feeds'].clear()
+    bot.say('all rss feeds deleted successfully')
+
+    _config_save(bot)
+
+    return NOLIMIT
+
+
 @commands('rssget')
 @example('.rssget <name>')
 def rssget(bot, trigger):
@@ -86,101 +158,74 @@ def rsslist(bot, trigger):
     feeds = bot.memory['rss']['feeds']
     bot.say('number of rss feeds: {}'.format(len(feeds)))
     for feed in feeds:
-        bot.say('{}: {} {} {} {}'.format(feeds.index(feed) + 1, feed['name'], feed['url'], feed['interval'], feed['channel']))
-    return NOLIMIT
-
-
-@require_admin
-@commands('rssadd')
-@example('.rssadd <name> <url> <interval> <channel>')
-def rssadd(bot, trigger):
-    # check number of parameters
-    for i in range(2,7):
-        if trigger.group(i) is None:
-            bot.say('syntax: .{} <name> <url> <interval> <channel>'.format(trigger.group(1)))
-            return NOLIMIT
-    # TODO: check that no parameter contains a comma
-
-    # get arguments
-    name = trigger.group(3)
-    url = trigger.group(4)
-    interval = trigger.group(5)
-    channel = trigger.group(6)
-
-    # check that feed name is not a number
-    try:
-        int(name)
-    except ValueError:
-        pass
-    else:
-        bot.say('feed name "{}" is invalid, it has to contain at least one letter'.format(name))
-        return NOLIMIT
-
-    # check that feed name is unique
-    for feed in bot.memory['rss']['feeds']:
-        if name == feed['name']:
-            bot.say('feed name "{}" is already in use, please choose a different one'.format(name))
-            return NOLIMIT
-
-    # check that feed url is online
-    try:
-        with urlopen(url) as f:
-            if f.status == 200:
-                # save config to memory
-                bot.memory['rss']['feeds'].append({'name':name,'url':url,'interval':interval,'channel':channel})
-                bot.say('rss feed "{}" added successfully'.format(url))
-    except:
-        bot.say('unable to add feed "{}": invalid url!'.format(url))
-        return NOLIMIT
-
-    config_save(bot)
-
-    return NOLIMIT
-
-
-@require_admin
-@commands('rssdel')
-@example('.rssdel <index>|<name>')
-def rssdel(bot, trigger):
-    # get arguments
-    arg = trigger.group(3)
-
-    if arg is None:
-        bot.say('syntax: .{} <index>|<name>'.format(trigger.group(1)))
-        return NOLIMIT
-
-    # check if arg is a number
-    try:
-        int(arg)
-    except ValueError:
-        # arg is not a number
-        _delFeedByName(bot, arg)
-    else:
-        # arg is a number
-        _delFeedByIndex(bot, int(arg))
-
-    config_save(bot)
-
-    return NOLIMIT
-
-
-# shoot yourself in the feet
-@require_privmsg
-@require_admin
-@commands('rssdeleteallfeeds')
-@example('.rssdeleteallfeeds')
-def rssdeleteallfeeds(bot, trigger):
-    # check number of parameters
-    if not trigger.group(2) is None:
-        bot.say('.{} must be called without parameters'.format(trigger.group(1)))
-        return NOLIMIT
-
-    bot.memory['rss']['feeds'].clear()
-    bot.say('all rss feeds deleted successfully')
+        bot.say('{}: {} {} {} {}'.format(feeds.index(feed) + 1, feed['channel'], feed['name'], feed['url'], feed['interval']))
     return NOLIMIT
 
 
 #####
+
+
+# read config from disk to memory
+def _config_read(bot):
+    if bot.config.rss.feeds and bot.config.rss.feeds[0]:
+        for feed in bot.config.rss.feeds:
+            atoms = feed.split(' ')
+            bot.memory['rss']['feeds'].append({'channel':atoms[0],'name':atoms[1],'url':atoms[2],'interval':atoms[3]})
+
+    print('Read config from disk!')
+
+    # sort list by channel name
+    bot.memory['rss']['feeds'].sort(key=operator.itemgetter('channel'))
+
+    print('Sorted feeds!')
+
+    # write config to disk after it has been sorted
+    _config_save(bot)
+
+
+# save config from memory to disk
+def _config_save(bot):
+
+    if not bot.memory['rss']['feeds']:
+        return NOLIMIT
+
+    # sort list by channel name
+    bot.memory['rss']['feeds'].sort(key=operator.itemgetter('channel'))
+
+    # flatten feeds for config file
+    feeds = []
+    for feed in bot.memory['rss']['feeds']:
+        feeds.append(feed['channel'] + ' ' + feed['name'] + ' ' + feed['url'] + ' ' + feed['interval'])
+    bot.config.rss.feeds = [",".join(feeds)]
+
+    try:
+        bot.config.save()
+        # TODO: remove the next line
+        print('Saved config to disk!')
+    except:
+        print('Unable to save config to disk!')
+
+
+def _delFeedByIndex(bot, index):
+    # read url of feed in order to give feedback after the feed has been deleted
+    try:
+        url = _getUrlByIndex(bot, index)
+    except:
+        bot.say('feed number "{}" doesn\'t exist!'.format(index))
+        return NOLIMIT
+
+    # delete feed
+    try:
+        if bot.memory['rss']['feeds'][index - 1]:
+            del((bot.memory['rss']['feeds'])[index - 1])
+            bot.say('rss feed "{}" deleted successfully'.format(url))
+    except:
+        bot.say('unable to delete feed "{}": feed number doesn\'t exist!'.format(index))
+
+
+def _delFeedByName(bot, name):
+    index = _getIndexByName(bot, name)
+    _delFeedByIndex(bot, index)
 
 
 def _getFeedUrlByName(bot, name):
@@ -199,25 +244,3 @@ def _getIndexByName(bot, name):
 
 def _getUrlByIndex(bot, index):
     return bot.memory['rss']['feeds'][index-1]['url']
-
-
-def _delFeedByName(bot, name):
-    index = _getIndexByName(bot, name)
-    _delFeedByIndex(bot, index)
-
-
-def _delFeedByIndex(bot, index):
-    # read url of feed in order to give feedback after the feed has been deleted
-    try:
-        url = _getUrlByIndex(bot, index)
-    except:
-        bot.say('feed number "{}" doesn\'t exist!'.format(index))
-        return NOLIMIT
-
-    # delete feed
-    try:
-        if bot.memory['rss']['feeds'][index - 1]:
-            del((bot.memory['rss']['feeds'])[index - 1])
-            bot.say('rss feed "{}" deleted successfully'.format(url))
-    except:
-        bot.say('unable to delete feed "{}": feed number doesn\'t exist!'.format(index))

--- a/rss.py
+++ b/rss.py
@@ -1,6 +1,5 @@
 import feedparser
 import operator
-from unidecode import unidecode
 from urllib.request import urlopen
 from sopel.tools import SopelMemory, SopelMemoryWithDefault
 from sopel.module import commands, example, interval, NOLIMIT, require_privmsg, require_admin
@@ -25,6 +24,7 @@ def configure(config):
     config.define_section('rss', RSSSection)
     config.rss.configure_setting('del_by_id', 'allow to delete feeds by index. this is potentially dangerous as the index of the remaining feeds may change after one feed has been deleted')
     config.rss.configure_setting('feeds', 'strings divided by a newline each consisting of channel, name, url and interval divided by spaces')
+
 
 def shutdown(bot):
     print('Shutting down!')
@@ -143,10 +143,11 @@ def rssget(bot, trigger):
         bot.say('syntax: .{} <name> [<scope>]'.format(trigger.group(1)))
         return NOLIMIT
 
-    # if chatty is True then bot.say feed item
+    # if chatty is True then the bot will post feed items to a channel
     chatty = False
 
     name = trigger.group(3)
+
     if (trigger.group(4) and trigger.group(4) == 'all'):
         chatty = True
 
@@ -293,13 +294,17 @@ def __setPositionByName(bot, name, position):
     bot.memory['rss']['feeds'][index]['position'] = position
 
 
-@interval(15)
+@interval(60)
 def __update(bot):
-    cycle = 15
+    cycle = 60
     uptime = bot.memory['rss']['uptime']
 
     # loop over feeds
     for feed in bot.memory['rss']['feeds']:
+
+        # FIXME
+        print("uptime: " + str(uptime))
+        print("feed['name'] (i=" + feed['interval'] + "): " + feed['name'])
 
         # check if feed should be updated
         # this line is the calculus when to trigger an update
@@ -338,8 +343,13 @@ def __updateFeed(bot, name, chatty):
 
     # print new or all items
     for item in reversed(feed['entries']):
+        # FIXME
+        print("chatty: " + str(chatty))
+
         if chatty:
-            bot.say(unidecode('\u0002[' + name + ']\u000F ' + item['title']) + ' \u0002→\u000F ' + item['link'], channel)
+            # FIXME
+            print('\u0002[' + name + ']\u000F ' + item['title'] + ' \u0002→\u000F ' + item['link'])
+            bot.say('\u0002[' + name + ']\u000F ' + item['title'] + ' \u0002→\u000F ' + item['link'], channel)
         if position == __normalizePosition(item['id']):
             chatty = True
         new_position = __normalizePosition(item['id'])

--- a/rss.py
+++ b/rss.py
@@ -183,14 +183,11 @@ def __update(bot):
 
     # loop over feeds
     for feed in bot.memory['rss']['feeds']:
+
         # check if feed should be updated
-
-        bot.say('uptime {}: {}'.format(feed['name'], uptime), '#freiburg')
-        bot.say('interval {}: {}'.format(feed['name'], int(feed['interval'])), '#freiburg')
-        bot.say('check {}: {}'.format(feed['name'], uptime % int(feed['interval'])), '#freiburg')
-
         if uptime % int(feed['interval']) < cycle:
-            # post update
+
+            # post updates
             __updateFeed(bot, feed['name'], False)
             bot.say('update {}!'.format(feed['name']), '#freiburg')
 

--- a/rss.py
+++ b/rss.py
@@ -382,10 +382,6 @@ def __updateFeed(bot, name, chatty):
         if chatty:
             message = '\u0002[' + name + ']\u000F '
             message += item['title'] + ' \u0002→\u000F ' + item['link']
-            try:
-                message += '(✎ ' + item['dc:creator'] + ')'
-            except:
-                pass
             bot.say(message, channel)
         new_position = __hashPosition(item['title'] + item['link'] + item['summary'])
         if position == new_position:

--- a/rss.py
+++ b/rss.py
@@ -1,126 +1,223 @@
-__author__ = "Fabio Tea <ft2011@gmail.com>"
-
 import feedparser
+from unidecode import unidecode
 from urllib.request import urlopen
 from sopel.tools import SopelMemory, SopelMemoryWithDefault
-from sopel.module import commands, example, NOLIMIT, require_privilege, OP, require_admin
+from sopel.module import commands, example, NOLIMIT, require_privmsg, require_admin
 from sopel.config.types import (StaticSection, ValidatedAttribute, ListAttribute)
 
 
 class RSSSection(StaticSection):
-    feeds = ListAttribute("feeds", default=[])
-    update_interval = ValidatedAttribute("update_interval", int, default=10)
+    feeds = ListAttribute('feeds', default=[])
 
 
 def setup(bot):
-    bot.config.define_section("rss", RSSSection)
-    bot.memory["rss"] = SopelMemory()
-    bot.memory["rss"]["feeds"] = []
-    bot.memory["rss"]["update_interval"] = 10
-
-    if bot.config.rss.feeds:
-        bot.memory["rss"]["feeds"] = bot.config.rss.feeds
-    if bot.config.rss.update_interval:
-        bot.memory["rss"]["update_interval"] = bot.config.rss.update_interval
+    bot.config.define_section('rss', RSSSection)
+    bot.memory['rss'] = SopelMemory()
+    bot.memory['rss']['feeds'] = []
+    config_read(bot)
 
 
 def configure(config):
-    config.define_section("rss", RSSSection)
-    config.rss.configure_setting("feeds", "Feed URLs")
-    config.rss.configure_setting("update_interval", "How often to check? (secounds)")
+    config.define_section('rss', RSSSection)
+    config.rss.configure_setting('feeds', 'strings divided by a newline each consisting of name, url, interval and channel divided by spaces')
 
+
+def config_read(bot):
+    if bot.config.rss.feeds[0]:
+        for feed in bot.config.rss.feeds:
+            atoms = feed.split(' ')
+            bot.memory['rss']['feeds'].append({'name':atoms[0],'url':atoms[1],'interval':atoms[2],'channel':atoms[3]})
+
+
+def config_save(bot):
+    # flatten feeds for config file
+    feeds = []
+    for feed in bot.memory['rss']['feeds']:
+        feeds.append(feed['name'] + ' ' + feed['url'] + ' ' + feed['interval'] + ' ' + feed['channel'])
+    bot.config.rss.feeds = [",".join(feeds)]
+
+    try:
+        bot.config.save()
+        # TODO: remove the next line
+        bot.say('saved config to disk!')
+    except:
+        bot.say('unable to save config to disk!')
 
 def shutdown(bot):
-    print("shutting down...")
-    bot.debug("RSS", "shutting down...", "always")
-    bot.config.rss.feeds = bot.memory["rss"]["feeds"]
-    bot.config.rss.update_interval = bot.memory["rss"]["update_interval"]
-    bot.config.save()
-
-    print(bot.config.rss.feeds)
-    bot.debug("RSS", bot.config.rss.feeds, "always")
-    bot.debug("RSS", bot.config.rss.update_interval, "always")
+    print('shutting down...')
+    bot.debug('rss', 'shutting down...', 'always')
+    config_save(bot)
 
 
 @require_admin
-@commands("rssget")
+@commands('rssget')
+@example('.rssget <name>')
 def rssget(bot, trigger):
-    if not trigger.group(2) is None:
-        bot.say("coming soon")
+    # check number of parameters
+    if trigger.group(3) is None or trigger.group(4):
+        bot.say('syntax: .{} <name>'.format(trigger.group(1)))
         return NOLIMIT
 
-        # rss = "http://lorem-rss.herokuapp.com/feed"
-        # feed = feedparser.parse(rss)
-        # for key in feed["entries"]:
-        #     bot.say(unidecode.unidecode(key["title"]))
+    name = trigger.group(3)
 
-
-@require_admin
-@commands("rsslist")
-@example(".rsslist")
-def rsslist(bot, trigger):
-    if not trigger.group(2) is None:
-        bot.say("expecting no parameter for this command...")
+    try:
+        url = _getFeedUrlByName(bot, name)
+        if url is None:
+            raise
+    except:
+        bot.say('url of feed "{}" couldn\'t be read!'.format(name))
         return NOLIMIT
 
-    feeds = bot.memory["rss"]["feeds"]
-    bot.say("RSS Feed URLs (#{}): ".format(len(feeds)))
-    for feed in feeds:
-        bot.say("{}: {}".format(feeds.index(feed) + 1, feed))
+    feed = feedparser.parse(url)
+    for key in feed['entries']:
+        bot.say(unidecode(key['title']) + ' - ' + key['link'])
     return NOLIMIT
 
 
 @require_admin
-@commands("rssadd")
-@example(".rssadd http://google.com")
-def rssadd(bot, trigger):
-    url = trigger.group(2)
-
-    if trigger.group(2) is None:
-        bot.say("expecting one parameter for this command...")
+@commands('rsslist')
+@example('.rsslist')
+def rsslist(bot, trigger):
+    # check number of parameters
+    if not trigger.group(2) is None:
+        bot.say('.{} must be called without parameters'.format(trigger.group(1)))
         return NOLIMIT
 
+    feeds = bot.memory['rss']['feeds']
+    bot.say('number of rss feeds: {}'.format(len(feeds)))
+    for feed in feeds:
+        bot.say('{}: {} {} {} {}'.format(feeds.index(feed) + 1, feed['name'], feed['url'], feed['interval'], feed['channel']))
+    return NOLIMIT
+
+
+@require_admin
+@commands('rssadd')
+@example('.rssadd <name> <url> <interval> <channel>')
+def rssadd(bot, trigger):
+    # check number of parameters
+    for i in range(2,7):
+        if trigger.group(i) is None:
+            bot.say('syntax: .{} <name> <url> <interval> <channel>'.format(trigger.group(1)))
+            return NOLIMIT
+    # TODO: check that no parameter contains a comma
+
+    # get arguments
+    name = trigger.group(3)
+    url = trigger.group(4)
+    interval = trigger.group(5)
+    channel = trigger.group(6)
+
+    # check that feed name is not a number
+    try:
+        int(name)
+    except ValueError:
+        pass
+    else:
+        bot.say('feed name "{}" is invalid, it has to contain at least one letter'.format(name))
+        return NOLIMIT
+
+    # check that feed name is unique
+    for feed in bot.memory['rss']['feeds']:
+        if name == feed['name']:
+            bot.say('feed name "{}" is already in use, please choose a different one'.format(name))
+            return NOLIMIT
+
+    # check that feed url is online
     try:
         with urlopen(url) as f:
             if f.status == 200:
-                bot.memory["rss"]["feeds"].append(url)
-                # bot.config.save()
-                bot.say("RSS feed '{}' added successfully".format(url))
-
+                # save config to memory
+                bot.memory['rss']['feeds'].append({'name':name,'url':url,'interval':interval,'channel':channel})
+                bot.say('rss feed "{}" added successfully'.format(url))
     except:
-        bot.say("Unable to add feed '{}' - Invalid URL!".format(url))
+        bot.say('unable to add feed "{}": invalid url!'.format(url))
+        return NOLIMIT
+
+    config_save(bot)
+
     return NOLIMIT
 
 
 @require_admin
-@commands("rssdel")
-@example(".rssdel 2")
+@commands('rssdel')
+@example('.rssdel <index>|<name>')
 def rssdel(bot, trigger):
-    idx = trigger.group(2)
+    # get arguments
+    arg = trigger.group(3)
 
-    if idx is None:
-        bot.say("expecting one parameter for this command...")
+    if arg is None:
+        bot.say('syntax: .{} <index>|<name>'.format(trigger.group(1)))
         return NOLIMIT
 
+    # check if arg is a number
     try:
-        if bot.memory["rss"]["feeds"][idx]:
-            bot.memory["rss"]["feeds"].remove(idx)
-            # bot.config.save()
-            bot.say("RSS feed '{}' deleted successfully".format(idx))
-    except:
-        bot.say("Unable to delete feed '{}' - No such index!".format(idx))
+        int(arg)
+    except ValueError:
+        # arg is not a number
+        _delFeedByName(bot, arg)
+    else:
+        # arg is a number
+        _delFeedByIndex(bot, int(arg))
+
+    config_save(bot)
+
     return NOLIMIT
 
 
+# shoot yourself in the feet
+@require_privmsg
 @require_admin
-@commands("rssclear")
-@example(".rssclear")
-def rssclear(bot, trigger):
+@commands('rssdeleteallfeeds')
+@example('.rssdeleteallfeeds')
+def rssdeleteallfeeds(bot, trigger):
+    # check number of parameters
     if not trigger.group(2) is None:
-        bot.say("expecting no parameter for this command...")
+        bot.say('.{} must be called without parameters'.format(trigger.group(1)))
         return NOLIMIT
 
-    bot.memory["rss"]["feeds"].clear()
-    # bot.config.save()
-    bot.say("All RSS feeds deleted successfully")
+    bot.memory['rss']['feeds'].clear()
+    bot.say('all rss feeds deleted successfully')
     return NOLIMIT
+
+
+#####
+
+
+def _getFeedUrlByName(bot, name):
+    feeds = bot.memory['rss']['feeds']
+    for feed in feeds:
+        if feed['name'] == name:
+            return feed['url']
+
+
+def _getIndexByName(bot, name):
+    feeds = bot.memory['rss']['feeds']
+    for feed in feeds:
+        if feed['name'] == name:
+            return feeds.index(feed)
+
+
+def _getUrlByIndex(bot, index):
+    return bot.memory['rss']['feeds'][index-1]['url']
+
+
+def _delFeedByName(bot, name):
+    index = _getIndexByName(bot, name)
+    _delFeedByIndex(bot, index)
+
+
+def _delFeedByIndex(bot, index):
+    # read url of feed in order to give feedback after the feed has been deleted
+    try:
+        url = _getUrlByIndex(bot, index)
+    except:
+        bot.say('feed number "{}" doesn\'t exist!'.format(index))
+        return NOLIMIT
+
+    # delete feed
+    try:
+        if bot.memory['rss']['feeds'][index - 1]:
+            del((bot.memory['rss']['feeds'])[index - 1])
+            bot.say('rss feed "{}" deleted successfully'.format(url))
+    except:
+        bot.say('unable to delete feed "{}": feed number doesn\'t exist!'.format(index))

--- a/rss.py
+++ b/rss.py
@@ -173,31 +173,6 @@ def rsslist(bot, trigger):
     return NOLIMIT
 
 
-#####
-
-
-@interval(15)
-def __update(bot):
-    cycle = 15
-    uptime = bot.memory['rss']['uptime']
-
-    # loop over feeds
-    for feed in bot.memory['rss']['feeds']:
-
-        # check if feed should be updated
-        if uptime % int(feed['interval']) < cycle:
-
-            # post updates
-            __updateFeed(bot, feed['name'], False)
-
-    # avoid upper limit of uptime variable size
-    if uptime > cycle * 10:
-        uptime %= cycle * 10
-
-    # increment uptime
-    bot.memory['rss']['uptime'] = uptime + cycle
-
-
 # read config from disk to memory
 def __config_read(bot):
     # feeds
@@ -316,6 +291,29 @@ def __normalizePosition(position):
 def __setPositionByName(bot, name, position):
     index = __getIndexByName(bot, name)
     bot.memory['rss']['feeds'][index]['position'] = position
+
+
+@interval(15)
+def __update(bot):
+    cycle = 15
+    uptime = bot.memory['rss']['uptime']
+
+    # loop over feeds
+    for feed in bot.memory['rss']['feeds']:
+
+        # check if feed should be updated
+        # this line is the calculus when to trigger an update
+        if uptime % int(feed['interval']) < cycle:
+
+            # post updates
+            __updateFeed(bot, feed['name'], False)
+
+    # avoid upper limit of uptime variable size
+    if uptime > cycle * 10:
+        uptime %= cycle * 10
+
+    # increment uptime
+    bot.memory['rss']['uptime'] = uptime + cycle
 
 
 def __updateFeed(bot, name, chatty):

--- a/rss.py
+++ b/rss.py
@@ -1,4 +1,3 @@
-import pprint
 import feedparser
 import operator
 import hashlib

--- a/rss.py
+++ b/rss.py
@@ -147,7 +147,7 @@ def rssget(bot, trigger):
         chatty = True
 
     try:
-        url = __getFeedUrlByName(bot, name)
+        url = __getUrlByName(bot, name)
         if url is None:
             raise Exception
     except:
@@ -160,13 +160,15 @@ def rssget(bot, trigger):
         bot.say('error reading feed "{}"'.format(url))
         return NOLIMIT
 
+    channel = __getChannelByName(bot, name)
+
     position = __getPositionByName(bot, name)
     new_position = position
 
     # print new or all items
     for item in reversed(feed['entries']):
         if chatty:
-            bot.say(unidecode(item['title']) + ' - ' + item['link'])
+            bot.say(unidecode('\u0002[' + name + ']\u000F ' + item['title']) + ' \u0002→\u000F ' + item['link'], channel)
         if position == __normalizePosition(item['id']):
             chatty = True
         new_position = __normalizePosition(item['id'])
@@ -274,7 +276,14 @@ def __delFeedByName(bot, name):
     __delFeedByIndex(bot, index)
 
 
-def __getFeedUrlByName(bot, name):
+def __getChannelByName(bot, name):
+    feeds = bot.memory['rss']['feeds']
+    for feed in feeds:
+        if feed['name'] == name:
+            return feed['channel']
+
+
+def __getUrlByName(bot, name):
     feeds = bot.memory['rss']['feeds']
     for feed in feeds:
         if feed['name'] == name:

--- a/rss.py
+++ b/rss.py
@@ -189,7 +189,6 @@ def __update(bot):
 
             # post updates
             __updateFeed(bot, feed['name'], False)
-            bot.say('update {}!'.format(feed['name']), '#freiburg')
 
     # avoid upper limit of uptime variable size
     if uptime > cycle * 10:

--- a/rss.py
+++ b/rss.py
@@ -242,11 +242,12 @@ def __config_save(bot):
     # flatten feeds for config file
     feeds = []
     for feed in bot.memory['rss']['feeds']:
+        position = ''
         try:
             if feed['position'] != 'NOPOSITION':
                 position = ' ' + __normalizePosition(feed['position'])
-        except KeyError:
-            position = ''
+        except:
+            pass
         feeds.append(feed['channel'] + ' ' + feed['name'] + ' ' + feed['url'] + ' ' + feed['interval'] + position)
     bot.config.rss.feeds = [",".join(feeds)]
 


### PR DESCRIPTION
I've implemented a new rss2irc module for sopel. My implementation uses the config file to store the feeds because I need to keep a copy in version control. I am currently testing this module in a production environment. There are still features to implement and probably bugs to fix but at least this is a first version of a working module again.

I've also written an [Ansible role](https://github.com/RebelCodeBase/ansible-role-sopel-runit-debian) to deploy sopel to Debian Jessie. It pulls [sopel](https://github.com/sopel-irc/sopel) and [sopel-rss](https://github.com/RebelCodeBase/sopel-rss) from github and uses [runit](http://smarden.org/runit/) to supervise the script.
